### PR TITLE
fix(proposal): Fixed typo revoke instead of revoked

### DIFF
--- a/src/contract/proposal.js
+++ b/src/contract/proposal.js
@@ -126,7 +126,7 @@ async function validateGatewayUpdateMember(content/* , context */) {
 async function validateGatewayContent(content/* , context */) {
   const gateway = await app.sdb.findOne('Gateway', { condition: { name: content.gateway } })
   if (!gateway) throw new Error('Gateway not found')
-  if (!gateway.revoke) throw new Error('Gateway is already revoked')
+  if (gateway.revoked) throw new Error('Gateway is already revoked')
 }
 
 module.exports = {


### PR DESCRIPTION
Dear @sqfasd , dear @liangpeili 

I fixed a small typo. `revoke` should be `revoked` on [proposal.js#Line129](https://github.com/AschPlatform/asch/blob/develop/src/contract/proposal.js#L129)
I also fixed the expression.

```diff
-  if (!gateway.revoke) throw new Error('Gateway is already revoked')
+  if (gateway.revoked) throw new Error('Gateway is already revoked')
```

All the best!
a1300