### PR TITLE
install front-end from asch-frontend-2 repo while building, add build all option

### DIFF
--- a/build.js
+++ b/build.js
@@ -4,6 +4,8 @@ const shell = require('shelljs')
 const moment = require('moment')
 const path = require('path')
 const pkg = require('./package')
+const console = require('console')
+const os = require('os')
 
 const buildTime = moment().format('HH:mm:ss DD/MM/YYYY')
 
@@ -35,7 +37,27 @@ function build(osVersion, netVersion) {
   shell.sed('-i', 'testnet', netVersion, `${fullPath}/app.js`)
   shell.sed('-i', 'DEFAULT_BUILD_TIME', buildTime, `${fullPath}/app.js`)
   shell.exec(`cd ${fullPath} && npm install --production`)
+
+  console.log('installing front-end, please be patient ...')
+  const magic = shell.exec('grep magic config.json | awk \'{print $2}\' | sed -e \'s/[",]//g\'', { silent: true }).stdout.trim()
+  const branch = shell.exec('git branch | grep \\* | cut -d \' \' -f2', { silent: true }).stdout.trim()
+  // It is quite possible that last build stop before cleanup frontend files
+  if (shell.test('-e', `${fullPath}/tmp/asch-frontend-2`)) {
+    shell.rm('-rf', `${fullPath}/tmp/asch-frontend-2`, { silent: true })
+  }
+  shell.exec(`cd ${fullPath}/tmp && pwd && git clone --single-branch -b ${branch} https://github.com/AschPlatform/asch-frontend-2.git \
+     && cd asch-frontend-2 && yarn install && pwd && sed -i '' 's/5f5b3cf5/${magic}/g' src/utils/constants.js \
+     && quasar build && cp -r dist/spa-mat/* ../../public/dist/ && rm -rf asch-frontend-2`, { silent: false })
+
+  // done, create tarball
   shell.exec(`cd ${fullPath}/.. && tar zcf ${dir}.tar.gz ${dir}`)
+  shell.exec(`ls -lh ${fullPath}.tar.gz`)
 }
 
-build(process.argv[2], process.argv[3])
+if (process.argv.length < 3) {
+  console.log('Usage: `node build.js all` or `node build.js os net`.\nSo far only host build, no cross building support yet. Net can be localnet, testnet or mainnet.')
+} else if (process.argv[2] === 'all') {
+  ['localnet', 'testnet', 'mainnet'].forEach(net => build(os.platform(), net))
+} else {
+  build(process.argv[2], process.argv[3])
+}


### PR DESCRIPTION
1. checkout frontend from asch-frontend-2 repo, build and copy into public/dist 
2. add 'all' option to build.js to build for all net type by single command